### PR TITLE
fix github pages root path

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -55,12 +55,6 @@ jobs:
           cache: ${{ steps.detect-package-manager.outputs.manager }}
       - name: Setup Pages
         uses: actions/configure-pages@v5
-        with:
-          # Automatically inject basePath in your Next.js configuration file and disable
-          # server side image optimization (https://nextjs.org/docs/api-reference/next/image#unoptimized).
-          #
-          # You may remove this line if you want to manage the configuration yourself.
-          static_site_generator: next
       - name: Restore cache
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Summary
- remove static_site_generator argument from github pages workflow to avoid injected basePath

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68487891a77c832fa252f9862970a4b7