### PR TITLE
Add missing pages report

### DIFF
--- a/missing-content.md
+++ b/missing-content.md
@@ -1,0 +1,38 @@
+# Report: Missing Pages
+
+This repository implements a Next.js web site with several pages such as `/projects`, `/contact`, `/legal`, etc. Navigation items in the footer reference additional routes that do not exist in the `src/app` directory.
+
+## Identified Missing Pages
+
+The following paths are referenced in `src/components/Footer/Footer.jsx` but no corresponding directories or files exist under `src/app`:
+
+- `/nft-trading`
+- `/first-hand-trade`
+- `/second-hand-trade`
+- `/sell-with-brickchain`
+- `/why-brickchain`
+- `/how-it-works`
+- `/security`
+- `/technology`
+- `/blog`
+- `/career`
+
+## Expected Content Overview
+
+Based on their names, these pages are likely intended to cover:
+
+| Path | Expected Content |
+|------|-----------------|
+|`/nft-trading`|Information about trading NFTs on the platform, such as available markets, guides, and benefits.|
+|`/first-hand-trade`|Details on buying newly tokenized properties or assets directly from Brickchain.|
+|`/second-hand-trade`|A marketplace or instructions for trading existing tokenized shares among users.|
+|`/sell-with-brickchain`|Guidelines for property owners who want to list assets for tokenization and sale on the platform.|
+|`/why-brickchain`|An introduction explaining the value proposition and advantages of using Brickchain.|
+|`/how-it-works`|Step-by-step explanation of the platform's business model and user process.|
+|`/security`|Information about security practices, smart-contract audits, and user safety.|
+|`/technology`|Overview of the technology stack, blockchain integrations, and technical features.|
+|`/blog`|Articles and updates covering news, tutorials, and platform announcements.|
+|`/career`|Job listings and hiring information for potential team members.|
+
+These pages are currently missing from the project and could be added under `src/app` if the functionality is desired.
+


### PR DESCRIPTION
## Summary
- add a report listing pages referenced in the footer that don't exist

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6848c791c5a8832f8d4dc89928038d5c